### PR TITLE
FIX: the gatsby link throws an unsecure warning with a www. in front

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ### Source code of [GaiAma.org](https://www.gaiama.org)
 
-> A lot of cleanup, refactoring, probably porting to [Gatsby v2](https://gatsby.org) will follow
+> A lot of cleanup, refactoring, probably porting to [Gatsby v2](https://www.gatsbyjs.org) will follow

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ### Source code of [GaiAma.org](https://www.gaiama.org)
 
-> A lot of cleanup, refactoring, probably porting to [Gatsby v2](https://www.gatsby.org) will follow
+> A lot of cleanup, refactoring, probably porting to [Gatsby v2](https://gatsby.org) will follow


### PR DESCRIPTION
Just noticed, that I get an unsecure connection warning, when clicking on the gatsby link in Firefox. Found out, that they use the URL without "www.", even though you somehow land on an url with www in front...